### PR TITLE
Add Lwt jobs bindings

### DIFF
--- a/META
+++ b/META
@@ -8,7 +8,7 @@ archive(native, plugin) = "osx_attr.cmxs"
 exists_if = "osx_attr.cma"
 
 package "lwt" (
-  requires = "osx-attr lwt"
+  requires = "osx-attr lwt.unix"
   archive(byte) = "osx_attr_lwt.cma"
   archive(byte, plugin) = "osx_attr_lwt.cma"
   archive(native) = "osx_attr_lwt.cmxa"

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ FINDLIB_NAME=osx-attr
 MOD_NAME=osx_attr
 
 OCAML_LIB_DIR=$(shell ocamlc -where)
-
+LWT_LIB_DIR=$(shell ocamlfind query lwt)
 CTYPES_LIB_DIR=$(shell ocamlfind query ctypes)
 
-OCAMLBUILD=CTYPES_LIB_DIR=$(CTYPES_LIB_DIR) OCAML_LIB_DIR=$(OCAML_LIB_DIR) \
+OCAMLBUILD=CTYPES_LIB_DIR=$(CTYPES_LIB_DIR)  \
+           OCAML_LIB_DIR=$(OCAML_LIB_DIR)    \
+           LWT_LIB_DIR=$(LWT_LIB_DIR)        \
 	ocamlbuild -use-ocamlfind -classic-display
 
 WITH_LWT=$(shell ocamlfind query threads lwt > /dev/null 2>&1 ; echo $$?)
@@ -33,6 +35,9 @@ INSTALL_LWT:=$(addprefix $(MOD_NAME)_lwt,$(TYPES)) \
              $(addprefix $(MOD_NAME)_lwt,$(TARGETS))
 
 INSTALL_LWT:=$(addprefix _build/lwt/,$(INSTALL_LWT))
+INSTALL_LWT:=$(INSTALL_LWT) \
+	      -dll _build/lwt/dll$(MOD_NAME)_lwt_stubs.so \
+	      -nodll _build/lwt/lib$(MOD_NAME)_lwt_stubs.a
 
 INSTALL+=$(INSTALL_LWT)
 endif

--- a/lib/osx_attr.mli
+++ b/lib/osx_attr.mli
@@ -84,30 +84,46 @@ module Value : sig
     | File : 'a File.t * 'a -> t
 end
 
-val getlist :
-  ?no_follow:bool -> ?size:int -> Query.t list -> string -> Value.t list
+module type S =
+sig
+  type _ t
 
-val fgetlist :
-  ?no_follow:bool -> ?size:int -> Query.t list -> Unix.file_descr ->
-  Value.t list
+  val getlist :
+    ?no_follow:bool -> ?size:int -> Query.t list -> string -> Value.t list t
 
-val getlistat :
-  ?no_follow:bool -> ?size:int -> Query.t list -> Unix.file_descr -> string ->
-  Value.t list
+  val fgetlist :
+    ?no_follow:bool -> ?size:int -> Query.t list -> Unix.file_descr ->
+    Value.t list t
 
-val get : ?no_follow:bool -> ?size:int -> 'a Select.t -> string -> 'a option
+  val getlistat :
+    ?no_follow:bool -> ?size:int -> Query.t list -> Unix.file_descr -> string ->
+    Value.t list t
 
-val fget :
-  ?no_follow:bool -> ?size:int -> 'a Select.t -> Unix.file_descr -> 'a option
+  val get : ?no_follow:bool -> ?size:int -> 'a Select.t -> string -> 'a option t
 
-val getat :
-  ?no_follow:bool -> ?size:int -> 'a Select.t -> Unix.file_descr -> string ->
-  'a option
+  val fget :
+    ?no_follow:bool -> ?size:int -> 'a Select.t -> Unix.file_descr -> 'a option t
 
-val setlist : ?no_follow:bool -> Value.t list -> string -> unit
+  val getat :
+    ?no_follow:bool -> ?size:int -> 'a Select.t -> Unix.file_descr -> string ->
+    'a option t
 
-val fsetlist : ?no_follow:bool -> Value.t list -> Unix.file_descr -> unit
+  val setlist : ?no_follow:bool -> Value.t list -> string -> unit t
 
-val set : ?no_follow:bool -> Value.t -> string -> unit
+  val fsetlist : ?no_follow:bool -> Value.t list -> Unix.file_descr -> unit t
 
-val fset : ?no_follow:bool -> Value.t -> Unix.file_descr -> unit
+  val set : ?no_follow:bool -> Value.t -> string -> unit t
+
+  val fset : ?no_follow:bool -> Value.t -> Unix.file_descr -> unit t
+end
+
+module Make
+    (M: sig
+       type 'a t
+       val return : 'a -> 'a t
+       val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
+     end)
+    (C: Osx_attr_bindings.S with type 'a t := 'a M.t) :
+  S with type 'a t := 'a M.t
+
+include S with type 'a t = 'a

--- a/lib_gen/osx_attr_bindgen.ml
+++ b/lib_gen/osx_attr_bindgen.ml
@@ -15,12 +15,6 @@
  *
  *)
 
-let headers = "\
-#include <sys/attr.h>\n\
-#include <unistd.h>\n\
-#include \"osx_attr_util.h\"\n\
-"
-
 let prefix = "osx_attr_"
 
 module Prefixed_bindings(F: Cstubs.FOREIGN) =
@@ -43,14 +37,21 @@ type configuration = {
 let standard_configuration = {
   errno = Cstubs.ignore_errno;
   concurrency = Cstubs.sequential;
-  headers;
+  headers = "\
+#include <sys/attr.h>\n\
+#include <unistd.h>\n\
+#include \"osx_attr_util.h\"\n\
+";
   bindings = (module Prefixed_bindings)
 }
 
 let lwt_configuration = {
   errno = Cstubs.return_errno;
   concurrency = Cstubs.lwt_jobs;
-  headers;
+  headers = "\
+#include <sys/attr.h>\n\
+#include <unistd.h>\n\
+";
   bindings = (module Osx_attr_bindings.C)
 }
 

--- a/lib_gen/osx_attr_bindgen.ml
+++ b/lib_gen/osx_attr_bindgen.ml
@@ -35,7 +35,7 @@ type configuration = {
 }
 
 let standard_configuration = {
-  errno = Cstubs.ignore_errno;
+  errno = Cstubs.return_errno;
   concurrency = Cstubs.sequential;
   headers = "\
 #include <sys/attr.h>\n\

--- a/lib_gen/osx_attr_bindgen.ml
+++ b/lib_gen/osx_attr_bindgen.ml
@@ -15,19 +15,68 @@
  *
  *)
 
-open Ctypes
+let headers = "\
+#include <sys/attr.h>\n\
+#include <unistd.h>\n\
+#include \"osx_attr_util.h\"\n\
+"
+
+let prefix = "osx_attr_"
+
+module Prefixed_bindings(F: Cstubs.FOREIGN) =
+struct
+  include Osx_attr_bindings.C(
+    struct
+      include F
+      let foreign f = F.foreign (prefix ^ f)
+    end
+    )
+end
+
+type configuration = {
+  errno: Cstubs.errno_policy;
+  concurrency: Cstubs.concurrency_policy;
+  headers: string;
+  bindings: (module Cstubs.BINDINGS)
+}
+
+let standard_configuration = {
+  errno = Cstubs.ignore_errno;
+  concurrency = Cstubs.sequential;
+  headers;
+  bindings = (module Prefixed_bindings)
+}
+
+let lwt_configuration = {
+  errno = Cstubs.return_errno;
+  concurrency = Cstubs.lwt_jobs;
+  headers;
+  bindings = (module Osx_attr_bindings.C)
+}
+
+let configuration = ref standard_configuration
+let ml_file = ref ""
+let c_file = ref ""
+
+let argspec : (Arg.key * Arg.spec * Arg.doc) list = [
+  "--ml-file", Arg.Set_string ml_file, "set the ML output file";
+  "--c-file", Arg.Set_string c_file, "set the C output file";
+  "--lwt-bindings", Arg.Unit (fun () -> configuration := lwt_configuration),
+  "generate Lwt jobs bindings";
+]
 
 let () =
-  let prefix = "caml_" in
-  let stubs_oc = open_out "lib/osx_attr_stubs.c" in
+  let () = Arg.parse argspec failwith "" in
+  if !ml_file = "" || !c_file = "" then
+    failwith "Both --ml-file and --c-file arguments must be supplied";
+  let {errno; concurrency; headers; bindings} = !configuration in  let prefix = "caml_" in
+  let stubs_oc = open_out !c_file in
   let fmt = Format.formatter_of_out_channel stubs_oc in
-  Format.fprintf fmt "#include <sys/attr.h>@.";
-  Format.fprintf fmt "#include <unistd.h>@.";
-  Format.fprintf fmt "#include \"osx_attr_util.h\"@.";
-  Cstubs.write_c fmt ~prefix (module Osx_attr_bindings.C);
+  Format.fprintf fmt "%s@." headers;
+  Cstubs.write_c ~errno ~concurrency fmt ~prefix bindings;
   close_out stubs_oc;
 
-  let generated_oc = open_out "lib/osx_attr_generated.ml" in
+  let generated_oc = open_out !ml_file in
   let fmt = Format.formatter_of_out_channel generated_oc in
-  Cstubs.write_ml fmt ~prefix (module Osx_attr_bindings.C);
+  Cstubs.write_ml ~errno ~concurrency fmt ~prefix bindings;
   close_out generated_oc

--- a/lib_gen/osx_attr_bindings.ml
+++ b/lib_gen/osx_attr_bindings.ml
@@ -25,7 +25,30 @@ let (??<) field int = field land int <> 0
 
 module Type = Osx_attr_types.C(Osx_attr_types_detected)
 
-module C(F: Cstubs.FOREIGN) = struct
+module type S =
+sig
+  open Unsigned
+
+  type 'a t
+
+  val getattrlist :
+    string -> Type.AttrList.t structure ptr -> unit ptr -> size_t -> ulong -> (int * int) t
+
+  val fgetattrlist :
+    int -> Type.AttrList.t structure ptr -> unit ptr -> size_t -> ulong -> (int * int) t
+
+  val getattrlistat :
+    int -> string -> Type.AttrList.t structure ptr -> unit ptr -> size_t -> ulong -> (int * int) t
+
+  val setattrlist :
+    string -> Type.AttrList.t structure ptr -> unit ptr -> size_t -> ulong -> (int * int) t
+
+  val fsetattrlist :
+    int -> Type.AttrList.t structure ptr -> unit ptr -> size_t -> ulong -> (int * int) t
+end
+
+module C(F: Cstubs.FOREIGN) =
+struct
 
   let getattrlist = F.(foreign "getattrlist" (
     string @-> ptr Type.AttrList.t @-> ptr void @-> size_t @-> ulong @->

--- a/lib_gen/osx_attr_bindings.ml
+++ b/lib_gen/osx_attr_bindings.ml
@@ -27,27 +27,27 @@ module Type = Osx_attr_types.C(Osx_attr_types_detected)
 
 module C(F: Cstubs.FOREIGN) = struct
 
-  let getattrlist = F.(foreign "osx_attr_getattrlist" (
+  let getattrlist = F.(foreign "getattrlist" (
     string @-> ptr Type.AttrList.t @-> ptr void @-> size_t @-> ulong @->
     returning int
   ))
 
-  let fgetattrlist = F.(foreign "osx_attr_fgetattrlist" (
+  let fgetattrlist = F.(foreign "fgetattrlist" (
     int @-> ptr Type.AttrList.t @-> ptr void @-> size_t @-> ulong @->
     returning int
   ))
 
-  let getattrlistat = F.(foreign "osx_attr_getattrlistat" (
+  let getattrlistat = F.(foreign "getattrlistat" (
     int @-> string @-> ptr Type.AttrList.t @-> ptr void @-> size_t @->
     ulong @-> returning int
   ))
 
-  let setattrlist = F.(foreign "osx_attr_setattrlist" (
+  let setattrlist = F.(foreign "setattrlist" (
     string @-> ptr Type.AttrList.t @-> ptr void @-> size_t @-> ulong @->
     returning int
   ))
 
-  let fsetattrlist = F.(foreign "osx_attr_fsetattrlist" (
+  let fsetattrlist = F.(foreign "fsetattrlist" (
     int @-> ptr Type.AttrList.t @-> ptr void @-> size_t @-> ulong @->
     returning int
   ))

--- a/lwt/_tags
+++ b/lwt/_tags
@@ -1,1 +1,5 @@
-<*.*>: package(lwt)
+<*.*>: package(lwt.unix), thread, package(ctypes.stubs)
+<*.*>: package(unix-type-representations), package(unix-errno)
+<osx_attr_lwt_stubs.c>: use_lwt, use_ctypes
+<*.{cma,cmxa}>: use_osx_attr_lwt_stubs
+

--- a/lwt/libosx_attr_lwt_stubs.clib
+++ b/lwt/libosx_attr_lwt_stubs.clib
@@ -1,0 +1,1 @@
+osx_attr_lwt_stubs.o

--- a/lwt/osx_attr_lwt.ml
+++ b/lwt/osx_attr_lwt.ml
@@ -14,3 +14,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+
+module Gen = Osx_attr_lwt_generated
+module G = Osx_attr_bindings.C(Gen)
+module C =
+struct
+  type 'a t = 'a Lwt.t
+
+  let getattrlist s a p l u = G.(getattrlist s a p l u).Gen.lwt
+  let fgetattrlist x a p l u = G.(fgetattrlist x a p l u).Gen.lwt
+  let getattrlistat x y a p l u = G.(getattrlistat x y a p l u).Gen.lwt
+  let setattrlist s a p l u = G.(setattrlist s a p l u).Gen.lwt
+  let fsetattrlist s a p l u = G.(fsetattrlist s a p l u).Gen.lwt
+end
+type 'a t = 'a Lwt.t
+include Osx_attr.Make(Lwt)(C)

--- a/lwt/osx_attr_lwt.mli
+++ b/lwt/osx_attr_lwt.mli
@@ -14,3 +14,5 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+
+include Osx_attr.S with type 'a t = 'a Lwt.t

--- a/lwt/osx_attr_lwt.mllib
+++ b/lwt/osx_attr_lwt.mllib
@@ -1,0 +1,2 @@
+Osx_attr_lwt
+Osx_attr_lwt_generated

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -42,7 +42,11 @@ dispatch begin
       ~prods:["lib/%_stubs.c"; "lib/%_generated.ml"]
       ~deps: ["lib_gen/%_bindgen.byte"]
       (fun env build ->
-        Cmd (A(env "lib_gen/%_bindgen.byte")));
+         Cmd (S[A(env "lib_gen/%_bindgen.byte");
+                A"--c-file";
+                A(env "lib/%_stubs.c");
+                A"--ml-file";
+                A(env "lib/%_generated.ml")]));
 
     copy_rule "cstubs: lib_gen/x_bindings.ml -> lib/x_bindings.ml"
       "lib_gen/%_bindings.ml" "lib/%_bindings.ml";

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -2,6 +2,7 @@ open Ocamlbuild_plugin;;
 open Ocamlbuild_pack;;
 
 let ctypes_libdir = Sys.getenv "CTYPES_LIB_DIR" in
+let lwt_libdir = Sys.getenv "LWT_LIB_DIR" in
 let ocaml_libdir = Sys.getenv "OCAML_LIB_DIR" in
 
 dispatch begin
@@ -48,6 +49,17 @@ dispatch begin
                 A"--ml-file";
                 A(env "lib/%_generated.ml")]));
 
+    rule "cstubs: lwt/x_bindings.ml -> x_stubs.c, x_generated.ml"
+      ~prods:["lwt/%_lwt_stubs.c"; "lwt/%_lwt_generated.ml"]
+      ~deps: ["lib_gen/%_bindgen.byte"]
+      (fun env build ->
+         Cmd (S[A(env "lib_gen/%_bindgen.byte");
+                A"--lwt-bindings";
+                A"--c-file";
+                A(env "lwt/%_lwt_stubs.c");
+                A"--ml-file";
+                A(env "lwt/%_lwt_generated.ml")]));
+
     copy_rule "cstubs: lib_gen/x_bindings.ml -> lib/x_bindings.ml"
       "lib_gen/%_bindings.ml" "lib/%_bindings.ml";
 
@@ -55,12 +67,14 @@ dispatch begin
     flag ["c"; "ocamlmklib"] & S[A"-L/usr/local/lib"];
     flag ["ocaml"; "link"; "native"; "program"] &
       S[A"-cclib"; A"-L/usr/local/lib";
-        A"-cclib"; A("-L"^Unix.getcwd()^"/_build/lib")];
+        A"-cclib"; A("-L"^Unix.getcwd()^"/_build/lib");
+        A"-cclib"; A("-L"^Unix.getcwd()^"/_build/lwt")];
 
     (* Linking cstubs *)
     dep ["c"; "compile"; "use_osx_attr_util"]
       ["lib/osx_attr_util.o"; "lib/osx_attr_util.h"];
     flag ["c"; "compile"; "use_ctypes"] & S[A"-I"; A ctypes_libdir];
+    flag ["c"; "compile"; "use_lwt"] & S[A"-I"; A lwt_libdir];
     flag ["c"; "compile"; "debug"] & A"-g";
 
     (* Linking generated stubs *)
@@ -74,6 +88,17 @@ dispatch begin
     flag ["ocaml"; "link"; "native"; "library"; "use_osx_attr_stubs"] &
     S[A"-cclib"; A"-losx_attr_stubs"];
 
+    (* Linking generated lwt stubs *)
+    dep ["ocaml"; "link"; "byte"; "library"; "use_osx_attr_lwt_stubs"]
+      ["lwt/dllosx_attr_lwt_stubs"-.-(!Options.ext_dll)];
+    flag ["ocaml"; "link"; "byte"; "library"; "use_osx_attr_lwt_stubs"] &
+    S[A"-dllib"; A"-losx_attr_lwt_stubs"];
+
+    dep ["ocaml"; "link"; "native"; "library"; "use_osx_attr_lwt_stubs"]
+      ["lwt/libosx_attr_lwt_stubs"-.-(!Options.ext_lib)];
+    flag ["ocaml"; "link"; "native"; "library"; "use_osx_attr_lwt_stubs"] &
+    S[A"-cclib"; A"-losx_attr_lwt_stubs"];
+ 
     (* Linking tests *)
     flag ["ocaml"; "link"; "byte"; "program"; "use_osx_attr_stubs"] &
       S[A"-dllib"; A"-losx_attr_stubs"];
@@ -84,6 +109,17 @@ dispatch begin
       S[A"-cclib"; A"-losx_attr_stubs"];
     dep ["ocaml"; "link"; "native"; "program"; "use_osx_attr_stubs"]
       ["lib/libosx_attr_stubs"-.-(!Options.ext_lib)];
+
+    (* Linking Lwt tests *)
+    flag ["ocaml"; "link"; "byte"; "program"; "use_osx_attr_lwt_stubs"] &
+      S[A"-dllib"; A"-losx_attr_lwt_stubs"];
+    dep ["ocaml"; "link"; "byte"; "program"; "use_osx_attr_lwt_stubs"]
+      ["lwt/dllosx_attr_lwt_stubs"-.-(!Options.ext_dll)];
+
+    flag ["ocaml"; "link"; "native"; "program"; "use_osx_attr_lwt_stubs"] &
+      S[A"-cclib"; A"-losx_attr_lwt_stubs"];
+    dep ["ocaml"; "link"; "native"; "program"; "use_osx_attr_lwt_stubs"]
+      ["lwt/libosx_attr_lwt_stubs"-.-(!Options.ext_lib)];
 
   | _ -> ()
 end;;

--- a/opam
+++ b/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "alcotest" {test}
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.6.2"}
   "unix-errno" {>= "0.4.0"}
   "base-unix"
   "unix-type-representations"


### PR DESCRIPTION
Add `Lwt` job variants of the functions in `Osx_attr`.

These are implemented by abstracting over the monad in the module that wraps the generated bindings, which leads to less duplication (but perhaps not more clarity) than a more direct implementation.

This PR also changes the existing bindings to use the new errno support in Ctypes 0.6.0.
