### PR TITLE
Add CMN_FILEID (inode) binding

### DIFF
--- a/lib/osx_attr.mli
+++ b/lib/osx_attr.mli
@@ -47,6 +47,7 @@ module Common : sig
     | ACCTIME : Time.Timespec.t t
     | BKUPTIME : Time.Timespec.t t
     | FNDRINFO : string t
+    | FILEID : int64 t
     | ADDEDTIME : Time.Timespec.t t
 end
 


### PR DESCRIPTION
Now `getattrlist` can retrieve all the non-dirfd parts of a `dirent` struct for a given path (inode, canonical name, type).

/cc @yallop 
